### PR TITLE
🐛 Check if there is a bounding box for OSM changeset

### DIFF
--- a/src/lib/@types/osm.ts
+++ b/src/lib/@types/osm.ts
@@ -74,23 +74,31 @@ export interface Changeset {
 
 	/**
 	 * Minimum latitude of the changeset
+	 *
+	 * Can be empty if the changeset is empty or only edits relations
 	 */
-	min_lat: number;
+	min_lat?: number;
 
 	/**
 	 * Minimum longitude of the changeset
+	 *
+	 * Can be empty if the changeset is empty or only edits relations
 	 */
-	min_lon: number;
+	min_lon?: number;
 
 	/**
 	 * Maximum latitude of the changeset
+	 *
+	 * Can be empty if the changeset is empty or only edits relations
 	 */
-	max_lat: number;
+	max_lat?: number;
 
 	/**
 	 * Maximum longitude of the changeset
+	 *
+	 * Can be empty if the changeset is empty or only edits relations
 	 */
-	max_lon: number;
+	max_lon?: number;
 
 	/**
 	 * UID of the user who created this changeset

--- a/src/lib/api/osm.ts
+++ b/src/lib/api/osm.ts
@@ -70,6 +70,13 @@ export const fetchOsmData = async (): Promise<Changeset[]> => {
 
 const geocodeChangeset = async (changeset: Changeset): Promise<string> => {
 	console.log(`[osm.ts] Determining location for ${changeset.id}`);
+
+	// Check if we actually have a bounding box
+	if (!changeset.max_lat || !changeset.max_lon || !changeset.min_lat || !changeset.min_lon) {
+		console.log(`[osm.ts] No bounding box for ${changeset.id}`);
+		return 'World';
+	}
+
 	const avgLon = (changeset.max_lon + changeset.min_lon) / 2;
 	const avgLat = (changeset.max_lat + changeset.min_lat) / 2;
 


### PR DESCRIPTION
Checks if an OSM changeset has a bounding box, since changesets that only edit relations don't have them, causing the update to fail.